### PR TITLE
Fix for http://github.com/appoxy/aws/issues#issue/13

### DIFF
--- a/lib/awsbase/right_awsbase.rb
+++ b/lib/awsbase/right_awsbase.rb
@@ -28,7 +28,7 @@ module Aws
     require 'cgi'
     require 'uri'
     require 'xmlsimple'
-    require 'active_support'
+    require 'active_support/core_ext'
 
     class AwsUtils #:nodoc:
         @@digest1 = OpenSSL::Digest::Digest.new("sha1")


### PR DESCRIPTION
With version 3 of ActiveSupport you need to require 'active_support/all' instead of require 'active_support' to get all of the methods that are expected by the aws gem.  This is backwards compatible with earlier ActiveSupport versions.
