### PR TITLE
Activesupport fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ begin
         gem.add_dependency 'uuidtools'
         gem.add_dependency 'http_connection'
         gem.add_dependency 'xml-simple'
+        gem.add_dependency 'activesupport', '<3.0.0'
     end
 rescue LoadError
     puts "Jeweler not available. Install it with: sudo gem install technicalpickles-jeweler -s http://gems.github.com"


### PR DESCRIPTION
I know this is not the best way to do this, but could you please pull this commit to fix the gem and release a new version?

Current version is unusable without the dependency because and your patch: http://github.com/appoxy/aws/commit/c49e6eb49b1e882e65f67de1e2e1dd6882c367ab
