### PR TITLE
Added :aws_name and :aws_description into Image and fixed filtering by image_type

### DIFF
--- a/lib/ec2/right_ec2.rb
+++ b/lib/ec2/right_ec2.rb
@@ -81,7 +81,7 @@ module Aws
     # Amazon EC2 Instance Types : http://www.amazon.com/b?ie=UTF8&node=370375011
     # Default EC2 instance type (platform)
     DEFAULT_INSTANCE_TYPE   =  'm1.small'
-    INSTANCE_TYPES          = ['m1.small','c1.medium','m1.large','m1.xlarge','c1.xlarge']
+    INSTANCE_TYPES          = ['t1.micro', 'm1.small','c1.medium','m1.large','m1.xlarge','c1.xlarge']
 
     @@bench = AwsBenchmarkingBlock.new
     def self.bench_xml


### PR DESCRIPTION
Hi these two patches will add :aws_name and :aws_description into Image object if this information is available.
Second patch will fix issue with filtering images using 'image_type' attributes.
