### PR TITLE
Appoxy master

### DIFF
--- a/lib/acf/right_acf_interface.rb
+++ b/lib/acf/right_acf_interface.rb
@@ -216,14 +216,12 @@ module Aws
     #     :caller_reference   => "200809102100536497863003"}
     #
     def create_distribution(origin, comment='', enabled=true, cnames=[], caller_reference=nil)
-      caller_reference ||= generate_call_reference
       body = distribution_config_for(origin, comment, enabled, cnames, caller_reference, false)
       request_hash = generate_request('POST', 'distribution', body.strip)
       merge_headers(request_info(request_hash, AcfDistributionParser.new))
     end
 
     def create_streaming_distribution(origin, comment='', enabled=true, cnames=[], caller_reference=nil)
-      caller_reference ||= generate_call_reference
       body = distribution_config_for(origin, comment, enabled, cnames, caller_reference, true)
       request_hash = generate_request('POST', 'streaming-distribution', body.strip)
       merge_headers(request_info(request_hash, AcfDistributionParser.new))
@@ -236,6 +234,8 @@ module Aws
       unless cnames.blank?
         cnames.to_a.each { |cname| cnames_str += "\n           <CNAME>#{cname}</CNAME>" }
       end
+      caller_reference ||= generate_call_reference
+      root_ob = config[:default_root_object] ? "<DefaultRootObject>#{config[:default_root_object]}</DefaultRootObject>" : ""
       body = <<-EOXML
         <?xml version="1.0" encoding="UTF-8"?>
         <#{rootElement} xmlns=#{xmlns}>
@@ -244,6 +244,7 @@ module Aws
            #{cnames_str.lstrip}
            <Comment>#{AcfInterface::escape(comment.to_s)}</Comment>
            <Enabled>#{enabled}</Enabled>
+           #{root_ob}
         </#{rootElement}>
       EOXML
     end


### PR DESCRIPTION
Cloudfront supports distributions for streaming audio and video, but uses different API calls for streaming vs. non-streaming distributions.

I've added methods for managing streaming CF distributions.
