### PR TITLE
Alternate fix for constantize under 1.8

### DIFF
--- a/lib/awsbase/support.rb
+++ b/lib/awsbase/support.rb
@@ -46,7 +46,13 @@ unless defined? ActiveSupport
 
             constant = Object
             names.each do |name|
-                constant = constant.const_get(name, false) || constant.const_missing(name)
+                if Module.method(:const_get).arity == 1
+                    # ruby 1.8
+                    constant = constant.const_defined?(name) ? constant.const_get(name) : constant.const_missing(name)
+                else
+                    # ruby 1.9
+                    constant = constant.const_get(name, false) || constant.const_missing(name)
+                end
             end
             constant
         end


### PR DESCRIPTION
This version checks the arity of const_get inline, and is a replacement for the more heavy handed fix in appoxy/aws#39
