### PR TITLE
require_relative does not exist in ruby < 1.9.2

### DIFF
--- a/lib/aws.rb
+++ b/lib/aws.rb
@@ -13,6 +13,7 @@ require 'rubygems'
 require 'right_http_connection'
 
 $:.unshift(File.dirname(__FILE__))
+require 'awsbase/require_relative'
 require 'awsbase/benchmark_fix'
 require 'awsbase/support'
 require 'awsbase/awsbase'

--- a/lib/awsbase/require_relative.rb
+++ b/lib/awsbase/require_relative.rb
@@ -1,0 +1,17 @@
+unless respond_to?(:require_relative)
+  class Object
+    # require_relative was introduced in 1.9.2. This makes it
+    # available to younger rubies.
+    # From: http://stackoverflow.com/questions/4333286/ruby-require-vs-require-relative-best-practice-to-workaround-running-in-both-r/4338241#4338241
+    def require_relative(relative_feature)
+      c = caller.first
+      fail "Can't parse #{c}" unless c.rindex(/:\d+(:in `.*')?$/)
+      file = $`
+      if /\A\((.*)\)/ =~ file # eval, etc.
+        raise LoadError, "require_relative is called in #{$1}"
+      end
+      absolute = File.expand_path(relative_feature, File.dirname(file))
+      require absolute
+    end
+  end
+end


### PR DESCRIPTION
This commit adds require_relative back for ruby < 1.9.2.
