### PR TITLE
Fixes keys_and_service method on Bucket in Ruby 1.9

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -119,9 +119,11 @@ module Aws
     def keys_and_service(options={}, head=false)
       opt = {}; options.each { |key, value| opt[key.to_s] = value }
       service_data = {}
+      service_list = {}
       thislist     = {}
       list         = []
       @s3.interface.incrementally_list_bucket(@name, opt) do |thislist|
+        service_list = thislist
         thislist[:contents].each do |entry|
           owner = S3::Owner.new(entry[:owner_id], entry[:owner_display_name])
           key   = S3::Key.new(self, entry[:key], nil, {}, {}, entry[:last_modified], entry[:e_tag], entry[:size], entry[:storage_class], owner)
@@ -129,8 +131,8 @@ module Aws
           list << key
         end
       end
-      thislist.each_key do |key|
-        service_data[key] = thislist[key] unless (key == :contents || key == :common_prefixes)
+      service_list.each_key do |key|
+        service_data[key] = service_list[key] unless (key == :contents || key == :common_prefixes)
       end
       [list, service_data]
     end


### PR DESCRIPTION
Hi,

due to the new block variables visibility rules in Ruby 1.9, the keys_and_service method in Bucket class always returns empty hash in the "service" part.

From the "Programming Ruby 1.9" book by Dave Thomas:
"(...) parameters to a block are now always local to a block, even if they have the same name as locals in the surrounding scope".

The commit addresses the issue. The fix is compatible with older versions of Ruby.

I guess there might be other places in the code vulnarable to similar issue, but so far I haven't seen any.

Best,
Mariusz
