### PR TITLE
Allow to force using bucket virtual hosting

### DIFF
--- a/lib/s3/s3.rb
+++ b/lib/s3/s3.rb
@@ -80,6 +80,7 @@ module Aws
     #    {:server       => 's3.amazonaws.com'   # Amazon service host: 's3.amazonaws.com'(default)
     #     :port         => 443                  # Amazon service port: 80 or 443(default)
     #     :protocol     => 'https'              # Amazon service protocol: 'http' or 'https'(default)
+    #     :virtual_hosting  => false            # Force using bucket virtual hosting: https://s3.amazonaws.com/my-bucket vs. https://my-bucket.s3.amazonaws.com
     #     :connection_mode  => :default         # options are
     #                                                  :default (will use best known safe (as in won't need explicit close) option, may change in the future)
     #                                                  :per_request (opens and closes a connection on every request)

--- a/lib/s3/s3_interface.rb
+++ b/lib/s3/s3_interface.rb
@@ -139,7 +139,7 @@ module Aws
       headers[:url].to_s[%r{^([a-z0-9._-]*)(/[^?]*)?(\?.+)?}i]
       bucket_name, key_path, params_list = $1, $2, $3
       # select request model
-      if is_dns_bucket?(bucket_name)
+      if is_dns_bucket?(bucket_name) and !@params[:virtual_hosting]
         # fix a path
         server   = "#{bucket_name}.#{server}"
         key_path ||= '/'


### PR DESCRIPTION
This is pretty important for Eucalyptus because in most cases DNS bucket access will be not available.

Aws::S3.new('access_key', 'secret_access_key', :virtual_hosting => true )

If :virtual_hosting => true is not specified - normal checking for DNS supported bucket name is executed.

Thanks!
