### PR TITLE
support for Eucalyptus cloud

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -1110,10 +1110,10 @@ module Aws
     #       :aws_size       => 94}
     #
     def create_volume(snapshot_id, size, zone)
+      params = {'Size' => size.to_s, 'AvailabilityZone' => zone.to_s}
+      params['SnapshotId'] = snapshot_id if snapshot_id && snapshot_id.length > 0 # snapshotId is conditional
       link = generate_request("CreateVolume",
-                              "SnapshotId"       => snapshot_id.to_s,
-                              "Size"             => size.to_s,
-                              "AvailabilityZone" => zone.to_s)
+                              params)
       request_info(link, QEc2CreateVolumeParser.new(:logger => @logger))
     rescue Exception
       on_exception

--- a/lib/s3/s3_interface.rb
+++ b/lib/s3/s3_interface.rb
@@ -139,16 +139,10 @@ module Aws
       headers[:url].to_s[%r{^([a-z0-9._-]*)(/[^?]*)?(\?.+)?}i]
       bucket_name, key_path, params_list = $1, $2, $3
       # select request model
-      if is_dns_bucket?(bucket_name)
-        # fix a path
-        server   = "#{bucket_name}.#{server}"
-        key_path ||= '/'
-        path     = "#{service}#{key_path}#{params_list}"
-      else
-        path = "#{service}/#{bucket_name}#{key_path}#{params_list}"
-      end
+      #if is_dns_bucket?(bucket_name) 
+      # is_dns_bucket isn't called since naming a bucket using URL's path always works (naming using dns cname may have an issue with Eucalyptus)
+      path = "#{service}/#{bucket_name}#{key_path}#{params_list}"
       path_to_sign = "#{service}/#{bucket_name}#{key_path}#{params_list}"
-#      path_to_sign = "/#{bucket_name}#{key_path}#{params_list}"
       [server, path, path_to_sign]
     end
 


### PR DESCRIPTION
Greetings,

I'm the engineer working at Eucalyptus systems.
In this patch, two changes were made to support Eucalyptus-backend in addition to EC2/S3.
- Naming a bucket in virtual hosted-style request (e.g., http://yourbucket.s3.amazonaws.com/yourobject) may have an issue with Eucalyptus. Because naming a bucket through URL path (e.g., http://s3.amazonaws.com/yourbucket/yourobject) always work with S3 and Eucalyptus, we changed the code that way.
- EC2 CreateVolume has an optional parameter 'SnapshotId', which appears on HTTP request only when it is set by user. Sending it with empty snapshot id (SnapshotId='') has an issue with Eucalyptus backend. So the patch removes the parameter when it's not set.

Both changes were tested against EC2/S3 and passed.
Thanks!
