### PR TITLE
I ran into this trying to use the library today.

### DIFF
--- a/lib/s3/bucket.rb
+++ b/lib/s3/bucket.rb
@@ -183,7 +183,6 @@ module Aws
     #
     def get(key, headers={})
       key = S3::Key.create(self, key.to_s) unless key.is_a?(S3::Key)
-      key.get(headers)
     end
 
     # Rename object. Returns Aws::S3::Key instance.


### PR DESCRIPTION
 method bucket.get(key_name) was not matching description. It is returning a string, but the description says it will return the key instance.
