### PR TITLE
added support for custom tags to broken QEc2DescribeSnapshotParser

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -1269,15 +1269,8 @@ module Aws
     #       :aws_status     => "pending",
     #       :aws_id         => "snap-d56783bc"}
     #
-<<<<<<< HEAD
-    def create_snapshot(volume_id, description=nil)
-      link = generate_request("CreateSnapshot",
-                              "VolumeId" => volume_id.to_s,
-                              "Description" => description)
-=======
     def create_snapshot(volume_id, options={})
       link = generate_request("CreateSnapshot", options.merge({"VolumeId" => volume_id.to_s}))
->>>>>>> upstream/master
       request_info(link, QEc2CreateSnapshotParser.new(:logger => @logger))
     rescue Exception
       on_exception
@@ -2235,5 +2228,6 @@ module Aws
   end
 
 end
+
 
 


### PR DESCRIPTION
The parser code in ec2.rb, line 2022:

  2021        def tagstart(name, attributes)
=> 2022          @snapshot = {} if name == 'item'
  2023        end

was failing on input like the following:

<?xml version="1.0" encoding="UTF-8"?>
<DescribeSnapshotsResponse xmlns="http://ec2.amazonaws.com/doc/
2010-08-31/">
   <requestId>b9cde6c8-29d1-4f5d-bd1b-3c8c1565535c</requestId>
   <snapshotSet>
       <item>
           <snapshotId>snap-121ec67e</snapshotId>
           ... tags removed for clarity...
           <description>c5 snap after April outage</description>
           <tagSet>
               <item>
                   <key>rotation_level</key>
                   <value>daily 1</value>
               </item>
           </tagSet>
       </item>
   </snapshotSet>
</DescribeSnapshotsResponse>

The problem is that <item> is being used in two different contexts,
and the Parser class is not keeping track of state.  I would expect to
see that custom tags added to snapshots would appear in the resultant
snapshot hash.  Instead, when they are encountered they wipe out all
of the hash attributes parsed so far for the snapshot.

This patch fixes the parser, custom tags like the one above:
 <item>
     <key>rotation_level</key>
     <value>daily 1</value>
 </item>

will appear in the snapshot hash as:
{ :aws_tag_rotation_level => 'daily 1' }
