### PR TITLE
Hi please consider this minor commit -  necessary for security groups

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -767,9 +767,12 @@ module Aws
           perms = []
           item.ipPermissions.each do |perm|
             perm.groups.each do |ngroup|
-              perms << {:group => ngroup.groupName,
-                        :owner => ngroup.userId}
-            end
+              perms << {:group_name => ngroup.groupName,
+                        :owner => ngroup.userId,
+                        :from_port => perm.fromPort,
+                        :to_port => perm.toPort,
+                        :protocol => perm.ipProtocol}
+              end
             perm.ipRanges.each do |cidr_ip|
               perms << {:from_port => perm.fromPort,
                         :to_port   => perm.toPort,


### PR DESCRIPTION
Fix minor issue in describe_security_groups - missing the protocol and port ranges when interpreting result of QEc2DescribeSecurityGroupsParser (though parser is getting this correctly).

Slightly related issue that may be of interest/you may know of + can help with:

the API docs @ http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/index.html?ApiReference-ItemType-SecurityGroupItemType.html  and also http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/index.html?ApiReference-query-DescribeSecurityGroups.html  show that each security group also has a 'groupId' returned in the response. I thought this was an issue with the QEc2DescribeSecurityGroupsParser but its not (though the parser is not trying to get this info currently). It seems the response from ec2 doesn't include this information - I've posted to https://forums.aws.amazon.com/thread.jspa?threadID=66553&tstart=0

all the best, marios
