### PR TITLE
Added support for attaching EBS snapshot when creating a new instance

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -564,7 +564,7 @@ module Aws
           if options[:block_device_mappings][n][:virtual_name]
             params["BlockDeviceMapping.#{n+1}.VirtualName"] = options[:block_device_mappings][n][:virtual_name] 
           end
-          if options[:block_device_mappings][n][:virtual_name]
+          if options[:block_device_mappings][n][:device_name]
             params["BlockDeviceMapping.#{n+1}.DeviceName"] = options[:block_device_mappings][n][:device_name]  
           end
           if options[:block_device_mappings][n][:ebs_snapshot_id]


### PR DESCRIPTION
Hi,

This patch will allow you to attach EBS snapshot when you're creating an instance.
BlockMappings schema was changed in EC2 query API so old way doesn't work anymore.

Syntax for attaching snapshots:

```
client.launch_instances('ami-8c1fece5', :instance_type => 'm1.small', 
  :block_device_mappings => [ {
  :virtual_name => 'test1',
  :ebs_snapshot_id => 'snap-3d860552',
  :device_name => '/dev/sdc'
} ] )
```

-- Michal
