### PR TITLE
Fixed launch_instance call if block_device_mappings is nil

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -559,7 +559,7 @@ module Aws
         # Otherwise, some of UserData symbols will be lost...
         params['UserData'] = Base64.encode64(options[:user_data]).delete("\n").strip unless Aws::Utils.blank?(options[:user_data])
       end
-      unless options[:block_device_mappings].blank?
+      if options[:block_device_mappings] and not options[:block_device_mappings].blank?
         options[:block_device_mappings].size.times do |n|
           if options[:block_device_mappings][n][:virtual_name]
             params["BlockDeviceMapping.#{n+1}.VirtualName"] = options[:block_device_mappings][n][:virtual_name] 


### PR DESCRIPTION
This patch will fix launch_instance call when block_device_mappings is nil. Sorry for this typo.

  -- Michal
