### PR TITLE
Fix issue created in commit 97ca145 by attempting to call blank? directly

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -559,7 +559,7 @@ module Aws
         # Otherwise, some of UserData symbols will be lost...
         params['UserData'] = Base64.encode64(options[:user_data]).delete("\n").strip unless Aws::Utils.blank?(options[:user_data])
       end
-      unless options[:block_device_mappings].blank?
+      unless Aws::Utils.blank?(options[:block_device_mappings])
         options[:block_device_mappings].size.times do |n|
           if options[:block_device_mappings][n][:virtual_name]
             params["BlockDeviceMapping.#{n+1}.VirtualName"] = options[:block_device_mappings][n][:virtual_name] 


### PR DESCRIPTION
Fix issue created in commit 97ca145 by attempting to call blank? directly on an option.  Need to wrap this into an Aws::Utils object to use the blank? method
