### PR TITLE
Security Groups and compatibiliby issue

### DIFF
--- a/lib/awsbase/utils.rb
+++ b/lib/awsbase/utils.rb
@@ -106,8 +106,8 @@ module Aws
     ]
     TO_REMEMBER = 'AZaz09 -_.!~*\'()'
     ASCII = {} # {'A'=>65, 'Z'=>90, 'a'=>97, 'z'=>122, '0'=>48, '9'=>57, ' '=>32, '-'=>45, '_'=>95, '.'=>}
-    TO_REMEMBER.each_char do |c| #unpack("c*").each do |c|
-      ASCII[c] = c.unpack("c")[0]
+    TO_REMEMBER.each_byte do |b|
+      ASCII[b.chr] = b.chr.unpack("c")[0]
     end
 #        puts 'ascii=' + ASCII.inspect
 


### PR DESCRIPTION
- Fix compatibility issue with ruby 1.8/1.9 (use "string".each_byte |b| b.chr, not "string".each_char) in utils.rb
- Update authorize/revoke securitygroups ingress for latest api version

Hi Travis, here's an update on my previous pull request. You were right about the "string".to_a not working for ruby 1.9. The version I use here is tested fine for ruby 1.8.6, 1.8.7, 1.9.2. 

The second commit reworks the Authorize and Revoke security groups ingress code. I believe the earlier implementations were based on http://docs.amazonwebservices.com/AWSEC2/2009-07-15/APIReference/ApiReference-query-AuthorizeSecurityGroupIngress.html . In the latest version of API, you can specify a number of IP addresses, or groups, or mix of both, for which the specified rule will apply. Also, in the earlier API you couldn't specify 'from_port' 'to_port' 'protocol' for groups whereas now you can.

I implemented authorize and revoke as one method 'manage_security_group_ingress' (with an action parameter to specify which), since the only difference between them is the 'action' - if you prefer you should seperate them into seperate methods. I also leave the original methods there in case you are concerned about backwards compatibility for earlier versions of this gem,

thanks for your time, all the best, marios
