### PR TITLE
Fix compatibility issue with ruby 1.8.6 (Hash[] doesn't work for 2d arrays)

### DIFF
--- a/lib/s3/s3_interface.rb
+++ b/lib/s3/s3_interface.rb
@@ -334,7 +334,7 @@ module Aws
     #     ]
     #   }
     def incrementally_list_bucket(bucket, options={}, headers={}, &block)
-      internal_options = Hash[ options.map {|k,v| [k.to_sym, v] } ]
+      internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
       begin
         internal_bucket = bucket.dup
         unless internal_options.nil? || internal_options.empty?


### PR DESCRIPTION
Hi Travis, 

I've come across another compatibility issue with ruby 1.8.6. The Hash[] operator doesn't work for 2d arrays. This is used in aws-2.5.3/lib/s3/s3_interface.rb line 337 ('def incrementally_list_bucket'). The workaround I propose here uses .inject but there are likely other solutions which you may prefer since admittedly this syntax may not be to everyone's taste (see http://stackoverflow.com/questions/740732/converting-an-array-of-keys-and-an-array-of-values-into-a-hash-in-ruby). I've tested this for ruby 1.8.6, 1.8.7, 1.9.2, output from irb below for you reference,

thanks for considering this, marios

=====RUBY 1.8.6 ERROR========

[marios@marios ~]$ ruby -v
ruby 1.8.6 (2010-09-02 patchlevel 420) [i386-linux]
[marios@marios ~]$ irb
irb(main):001:0> options = {}
=> {}
irb(main):002:0> Hash[options.map {|k,v| [k.to_sym, v] }]
ArgumentError: odd number of arguments for Hash
    from (irb):2:in `[]'
    from (irb):2
    from :0

=====RUBY 1.8.6 OK===========

[marios@marios ~]$ ruby -v
ruby 1.8.6 (2010-09-02 patchlevel 420) [i386-linux]
[marios@marios ~]$ irb
irb(main):001:0> options = {}
=> {}
irb(main):002:0> internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
=> {}
irb(main):003:0> internal_options
=> {}
irb(main):004:0> options = { 'prefix'=>'t', 'marker'=>'', 'max-keys'=>5, 'delimiter'=>'' }
=> {"max-keys"=>5, "prefix"=>"t", "marker"=>"", "delimiter"=>""}
irb(main):005:0> internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
=> {:marker=>"", :delimiter=>"", :"max-keys"=>5, :prefix=>"t"}
irb(main):006:0> internal_options
=> {:marker=>"", :delimiter=>"", :"max-keys"=>5, :prefix=>"t"}
irb(main):007:0> 

=====RUBY 1.8.7 OK===========

[marios@marios ~]$ ruby -v
ruby 1.8.7 (2010-08-16 patchlevel 302) [i686-linux]
[marios@marios ~]$ irb
ruby-1.8.7-p302 :001 > options = {}
 => {} 
ruby-1.8.7-p302 :002 > internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
 => {} 
ruby-1.8.7-p302 :003 > options = { 'prefix'=>'t', 'marker'=>'', 'max-keys'=>5, 'delimiter'=>'' }
 => {"prefix"=>"t", "marker"=>"", "delimiter"=>"", "max-keys"=>5} 
ruby-1.8.7-p302 :004 > internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
 => {:prefix=>"t", :"max-keys"=>5, :marker=>"", :delimiter=>""} 
ruby-1.8.7-p302 :005 > internal_options
 => {:prefix=>"t", :"max-keys"=>5, :marker=>"", :delimiter=>""} 
ruby-1.8.7-p302 :006 > 

=====RUBY 1.9.2 OK===========

[marios@marios ~]$ ruby -v
ruby 1.9.2p136 (2010-12-25 revision 30365) [i686-linux]
[marios@marios ~]$ irb
ruby-1.9.2-p136 :001 > options = {}
 => {} 
ruby-1.9.2-p136 :002 > internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
 => {} 
ruby-1.9.2-p136 :003 > internal_options
 => {} 
ruby-1.9.2-p136 :004 > options = { 'prefix'=>'t', 'marker'=>'', 'max-keys'=>5, 'delimiter'=>'' }
 => {"prefix"=>"t", "marker"=>"", "max-keys"=>5, "delimiter"=>""} 
ruby-1.9.2-p136 :005 > internal_options = (options.map {|k,v| [k.to_sym, v] }).inject({}) {|h, ar| h[ar[0]] = ar[1]; h}
 => {:prefix=>"t", :marker=>"", :"max-keys"=>5, :delimiter=>""} 
ruby-1.9.2-p136 :006 > internal_options
 => {:prefix=>"t", :marker=>"", :"max-keys"=>5, :delimiter=>""} 
ruby-1.9.2-p136 :007 > 
