### PR TITLE
We've been using my version of require_relative (overwriting yours via config/preinitializer.rb) for a while now with no problems.

### DIFF
--- a/lib/awsbase/require_relative.rb
+++ b/lib/awsbase/require_relative.rb
@@ -1,11 +1,20 @@
 # require_relative was introduced in 1.9.2. This makes it
-# available to younger rubies.
-# From: http://stackoverflow.com/questions/4333286/ruby-require-vs-require-relative-best-practice-to-workaround-running-in-both-r/4338241#4338241
+# available to younger rubies.  It trys hard to not re-require
+# files.
+
 unless Kernel.respond_to?(:require_relative)
   module Kernel
     def require_relative(path)
-#      puts 'IN NEW REQUIRE_RELATIVE ' + path.to_s
-      require File.join(File.dirname(caller[0]), path.to_str)
+      desired_path = File.expand_path('../' + path.to_str, caller[0])
+      shortest = desired_path
+      $:.each do |path|
+        path += '/'
+        if desired_path.index(path) == 0
+          candidate = desired_path.sub(path, '')
+          shortest = candidate if candidate.size < shortest.size
+        end
+      end
+      require shortest
     end
   end
 end


### PR DESCRIPTION
I've tested this version in our own code and it seems to work fine.
