### PR TITLE
Add describe_owned_snapshots method to list the snapshots we own

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -1309,6 +1309,18 @@ module Aws
     rescue Exception
       on_exception
     end
+    
+    def describe_owned_snapshots(list=[])
+      params = {"Owner" => "self"}
+      snap_ids = hash_params('SnapshotId', list.to_a)
+      params.update(snap_ids)
+      link = generate_request("DescribeSnapshots",
+                              params)
+      request_cache_or_info :describe_owned_snapshots, link, QEc2DescribeSnapshotsParser, @@bench, list.nil? || list.empty?
+    rescue Exception
+      on_exception
+    end
+    
 
     # Create a snapshot of specified volume.
     #


### PR DESCRIPTION
This is a quick and dirty addition to create a way to list owned snapshots.  As a next step, I'd generalize this into a single method with an optional owner option, but I'm not sure what the direction of this branch is, nor if the version 3 branch is anywhere near primetime yet.

Feedback welcome!
