### PR TITLE
Fix for JRuby LocalJumpError

### DIFF
--- a/lib/awsbase/awsbase.rb
+++ b/lib/awsbase/awsbase.rb
@@ -314,12 +314,12 @@ module Aws
           puts 'RETRYING QUERY due to QueryTimeout...' if count > 0
           begin
             ret = request_info_impl(http_conn, bench, request, parser, options, &block)
-            break
           rescue Aws::AwsError => ex
             if !ex.include?(/QueryTimeout/) || count == retry_count
               raise ex
             end
           end
+          break if ret
           count += 1
         end
       ensure


### PR DESCRIPTION
Hello,

When using the aws gem under JRuby (I'm testing under 1.6.5), I noticed intermittent crashing with a "LocalJumpError". I would make a failing test case, but it's more of an acceptance issue, so I'm not sure exactly where I'd put that. In any case, you can reproduce with:

```
ruby -rubygems -e "require 'aws'; loop { Aws::S3.new(ENV['AWS_ID'], ENV['AWS_SECRET']).buckets }"
```

Where I have environment variables set for my AWS credentials.

I think the issue has something to do with a difference in how MRI and JRuby represent begin/end blocks internally, but I didn't dig too far into it. Let me know if you have any questions or comments.
