### PR TITLE
Added rootDeviceType attribute to AWS image

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -1612,6 +1612,12 @@ module Aws
             @image[:aws_kernel_id] = @text
           when 'ramdiskId' then
             @image[:aws_ramdisk_id] = @text
+          when 'rootDeviceType' then
+            @image[:aws_root_device_type] = @text
+          when 'rootDeviceName' then
+            @image[:aws_root_device_name] = @text
+          when 'hypervisor' then
+            @image[:aws_hypervisor] = @text
           when 'item' then
             @result << @image if @xmlpath[%r{.*/imagesSet$}]
         end


### PR DESCRIPTION
Hi,

This small patch should add rootDeviceType to the Image model in AWS. This attribute is necessary in decision making like what instance_profile to use for launching an instance.
In addition I added rootDeviceName and hypervisor attributes, which may be handy for someone.

Cheers,
  -- michal
