### PR TITLE
Grab Endpoint from PermanentRedirect XML body when this is returned

### DIFF
--- a/lib/awsbase/errors.rb
+++ b/lib/awsbase/errors.rb
@@ -214,7 +214,7 @@ module Aws
           last_errors_text     = @aws.last_errors.flatten.join("\n")
           # on redirect :
           if redirect_detected
-            location = response['location']
+            location = response['location'] ||  "#{request[:protocol]}://#{error_parser.instance_variable_get(:'@endpoint')}"
             # ... log information and ...
             @aws.logger.info("##### #{@aws.class.name} redirect requested: #{response.code} #{response.message} #####")
             @aws.logger.info("##### New location: #{location} #####")

--- a/lib/awsbase/parsers.rb
+++ b/lib/awsbase/parsers.rb
@@ -196,9 +196,9 @@ module Aws
           @code = @text
         when 'Message';
           @message = @text
-#       when 'Endpoint'  ; @endpoint  = @text
-#       when 'HostId'    ; @host_id   = @text
-#       when 'Bucket'    ; @bucket    = @text
+        when 'Endpoint'  ; @endpoint  = @text
+        when 'HostId'    ; @host_id   = @text
+        when 'Bucket'    ; @bucket    = @text
         when 'Error';
           @errors << [@code, @message]
       end


### PR DESCRIPTION
Hi,

please consider this minor edit. The scenario is: 
- create a bucket "marios-test-bucket.foo" in ap-north-east-1 and then try to access this from a different server endpoint - such as ap-south-east-1, i.e.:
  
  ```
  client = Aws::S3.new("KEY", "SECRET", {:server=>"s3-ap-southeast-1.amazonaws.com", :connection_mode=>:per_thread})
  bucket = client.bucket("marios-test-bucket.foo")
  bucket.keys
  ```
- AWS responds with "301 Moved Permanently":
  
  ```
  >> response
  => #<Net::HTTPMovedPermanently 301 Moved Permanently readbody=true>
  
  >> response.body
  => "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
        <Error>
        <Code>PermanentRedirect</Code>
        <Message>The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.</Message>
        <RequestId>414883F22C6F5799</RequestId>
        <Bucket>marios-test-bucket.foo</Bucket>
        <HostId>CkUSF4xXXgrt8/ggfBrEudibTUn6E0tbPHU72k7FhSeeAeTtTMIiWVywFTGilZja</HostId>
         <Endpoint>marios-test-bucket.foo.s3-ap-northeast-1.amazonaws.com</Endpoint>
         </Error>"
  ```
- This minor edit grabs the Endpoint from the response and lets the code retry the connection

I noticed that this code was commented out in the first place (from the parser I mean) and was wondering if there was a reason for that (introduced other problems?),

thanks for your time, marios
