### PR TITLE
deal with HEAD requests on objects which fail when a redirect is returned

### DIFF
--- a/lib/awsbase/errors.rb
+++ b/lib/awsbase/errors.rb
@@ -214,7 +214,8 @@ module Aws
           last_errors_text     = @aws.last_errors.flatten.join("\n")
           # on redirect :
           if redirect_detected
-            location = response['location'] ||  "#{request[:protocol]}://#{error_parser.instance_variable_get(:'@endpoint')}"
+            endpoint = error_parser.instance_variable_get(:'@endpoint')
+            location = response['location'] || (endpoint == "s3.amazonaws.com")?  "#{request[:protocol]}://#{error_parser.instance_variable_get(:'@bucket')}.#{endpoint}" : "#{request[:protocol]}://#{endpoint}" 
             # ... log information and ...
             @aws.logger.info("##### #{@aws.class.name} redirect requested: #{response.code} #{response.message} #####")
             @aws.logger.info("##### New location: #{location} #####")


### PR DESCRIPTION
Hi Travis,

please consider this minor addition - it is related/builds on my previous pull request [110](https://github.com/appoxy/aws/pull/110) ... so the scenario is the same as in you have a bucket in a particular location (e.g. **ap-south-east-1** ) and you are trying to GET that bucket whilst talking to a different S3 endpoint - like **eu-west-1** for example. Pull request 110 dealt with **GET /bucket** - aws responds with a PermanentRedirect which the client can parse and make a new request to the correct endpoint.

However, in the case of **HEAD /bucket/object** (i.e. get details about an object but not the object data itself)... you don't get the XML body containing the correct endpoint - since this is a HEAD request. AWS also do not set the 'location' header so there is no way to identify the correct endpoint. I posted a question on the AWS forum but haven't heard anything so far... https://forums.aws.amazon.com/thread.jspa?messageID=340398

Now, to GET the object, you have to first GET the bucket:

```
    client = Aws::S3.new("KEY", "SECRET", {:server=>"s3-ap-southeast-1.amazonaws.com", :connection_mode=>:per_thread})
    bucket = client.bucket("marios-test-bucket.foo")
    blob = s3_bucket.key(opts[:id], true)
```

The best solution I could come up with is to save the endpoint after a successful GET on the bucket, and use that endpoint when doing the HEAD against the object. 

many thanks for considering this request, marios
