### PR TITLE
fix regex used to grab uploadId parameter in multipart uploads

### DIFF
--- a/lib/s3/s3_interface.rb
+++ b/lib/s3/s3_interface.rb
@@ -115,10 +115,10 @@ module Aws
       out_string << '?logging' if path[/[&?]logging($|&|=)/] # this one is beta, no support for now
       #... also deal with params for multipart uploads API
       out_string << '?uploads' if path[/\?uploads$/]
-      if path[/\?uploadId=(\w*)$/]
+      if path[/\?uploadId=(.*)$/]
         out_string << "?uploadId=#{$1}"
       end
-      if path[/\?partNumber=(\w*)&uploadId=(\w*)$/]
+      if path[/\?partNumber=(\d*)&uploadId=(.*)$/]
         out_string << "?partNumber=#{$1}&uploadId=#{$2}"
       end
       out_string


### PR DESCRIPTION
 I noticed an issue with one regex used to extract the 'uploadId' parameter. Basically, the Id can include characters like '.' e.g. this is a valid uploadId I got today:

"pCz.6i8XVQHubk9RxTgufJPjXFXp1O6LfaXgM3LBCw82GcO5Eb8WfsUGNuj.jqR3CS5Y1nh8MNU55fB5mdw.PkBO1J3sh5bXgj6.hcppoi7V_73PluHJDt8p1bQqV1we"

(can include more than just \w - needs .*)
