### PR TITLE
Use default version parameter when endpoint_url is configured

### DIFF
--- a/lib/awsbase/awsbase.rb
+++ b/lib/awsbase/awsbase.rb
@@ -145,6 +145,7 @@ module Aws
         @params[:port] = URI.parse(@params[:endpoint_url]).port
         @params[:service] = URI.parse(@params[:endpoint_url]).path
         @params[:protocol] = URI.parse(@params[:endpoint_url]).scheme
+        @params[:api_version] ||= service_info[:api_version]
         @params[:region] = nil
       else
         @params[:server] ||= service_info[:default_host]


### PR DESCRIPTION
The version parameter is (technically) required for ELB but is not present by default when an endpoint_url is configured.
