### PR TITLE
return false on Aws::S3#bucket fails

### DIFF
--- a/lib/s3/s3.rb
+++ b/lib/s3/s3.rb
@@ -114,6 +114,8 @@ module Aws
     # affect on the bucket's ACL if the bucket already exists.
     # Returns a Aws::S3::Bucket instance or +nil+ if the bucket does not exist
     # and +create+ is not set.
+    # If +create+ is true, false will be returned if an error occurs. Such as the
+    # bucket already exists
     #
     #  s3 = Aws::S3.new(aws_access_key_id, aws_secret_access_key)
     #  bucket1 = s3.bucket('my_awesome_bucket_1')
@@ -129,7 +131,10 @@ module Aws
     #
     def bucket(name, create=false, perms=nil, headers={})
       headers['x-amz-acl'] = perms if perms
-      @interface.create_bucket(name, headers) if create
+      if create
+        created_bucket = @interface.create_bucket(name, headers)
+        return false unless created_bucket
+      end
       return Bucket.new(self, name)
       # The old way below was too slow and unnecessary because it retreived all the buckets every time.
       #            owner = Owner.new(entry[:owner_id], entry[:owner_display_name])

--- a/lib/s3/s3_interface.rb
+++ b/lib/s3/s3_interface.rb
@@ -206,7 +206,8 @@ module Aws
       on_exception
     end
 
-    # Creates new bucket. Returns +true+ or an exception.
+    # Creates new bucket. Returns +true+ or an exception, will return false if
+    # the exception includes 'BucketAlreadyOwnedByYou'
     #
     #  # create a bucket at American server
     #  s3.create_bucket('my-awesome-bucket-us') #=> true
@@ -225,7 +226,7 @@ module Aws
       request_info(req_hash, RightHttp2xxParser.new)
     rescue Exception => e
       # if the bucket exists AWS returns an error for the location constraint interface. Drop it
-      e.is_a?(Aws::AwsError) && e.message.include?('BucketAlreadyOwnedByYou') ? true : on_exception
+      e.is_a?(Aws::AwsError) && e.message.include?('BucketAlreadyOwnedByYou') ? false : on_exception
     end
 
     # Retrieve bucket location


### PR DESCRIPTION
This PR is in response to #136, Aws::S3#bucket will now return false is the the create argument is true and an execption is raised in Aws::S3Interface#create_bucket (which also now returns false) 

I have not being able to get test these changes as i cant get `rake tests3` to work at all right now.