### PR TITLE
Fix hash_params_with_suffix (issue #138)

### DIFF
--- a/lib/ec2/ec2.rb
+++ b/lib/ec2/ec2.rb
@@ -185,7 +185,7 @@ module Aws
 
     def hash_params_with_suffix(prefix, suffix, list) #:nodoc:
       groups = {}
-      list.each_index { |i| groups.update("#{prefix}.#{i+1}.suffix"=>list[i]) }
+      list.each_index { |i| groups.update("#{prefix}.#{i+1}.#{suffix}"=>list[i]) }
       return groups
     end
 


### PR DESCRIPTION
This fixes issue #138, where the hash_params_with_suffix method uses the fixed string 'suffix' instead of the value of the variable.